### PR TITLE
added delete contact UI

### DIFF
--- a/app/javascript/src/components/Dashboard/Contacts/DeleteAlert.jsx
+++ b/app/javascript/src/components/Dashboard/Contacts/DeleteAlert.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+import { Check } from "@bigbinary/neeto-icons";
+import { Modal, Typography, Button, Toastr } from "neetoui";
+
+const DeleteAlert = ({ refetch, onClose }) => {
+  const handleDelete = () => {
+    try {
+      Toastr.success("Contact deleted successfully!!");
+      onClose();
+      refetch();
+    } catch (error) {
+      logger.error(error);
+    }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose} size="md" closeButton={false}>
+      <Modal.Header>
+        <Typography style="h2">Delete Contact</Typography>
+      </Modal.Header>
+      <Modal.Body>
+        <Typography style="body2" lineHeight="normal">
+          Are you sure you want to delete this contact? These changes cannot be
+          undone.
+        </Typography>
+      </Modal.Body>
+      <Modal.Footer className="space-x-2">
+        <Button
+          size="large"
+          label="Continue"
+          iconPosition="right"
+          icon={Check}
+          onClick={handleDelete}
+        />
+        <Button style="text" size="large" label="Cancel" onClick={onClose} />
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default DeleteAlert;

--- a/app/javascript/src/components/Dashboard/Contacts/Table.jsx
+++ b/app/javascript/src/components/Dashboard/Contacts/Table.jsx
@@ -1,18 +1,44 @@
 import React from "react";
 
-import { Table as NeetoUITable } from "neetoui";
+import { MenuHorizontal } from "@bigbinary/neeto-icons";
+import { Table as NeetoUITable, Button } from "neetoui";
 
 import { NOTES_TABLE_COLUMN_DATA } from "./constants";
 
-const Table = ({ contacts }) => (
-  <div className="notes-table-height w-full">
-    <NeetoUITable
-      defaultPageSize={10}
-      rowData={contacts}
-      columnData={NOTES_TABLE_COLUMN_DATA}
-      allowRowClick={true}
-    />
-  </div>
+const AlertContext = React.createContext();
+
+const useDeletAlertContext = () => {
+  const { setShowDeleteAlert } = React.useContext(AlertContext);
+
+  if (!setShowDeleteAlert) {
+    throw new Error(
+      "setShowDeleteAlert is only available inside AlertContext provider"
+    );
+  }
+
+  return { setShowDeleteAlert };
+};
+
+const RowSettingsIcon = () => {
+  const { setShowDeleteAlert } = useDeletAlertContext();
+
+  return (
+    <Button style="text" icon={MenuHorizontal} onClick={setShowDeleteAlert} />
+  );
+};
+
+const Table = ({ contacts, setShowDeleteAlert }) => (
+  <AlertContext.Provider value={{ setShowDeleteAlert }}>
+    <div className="notes-table-height w-full">
+      <NeetoUITable
+        defaultPageSize={10}
+        rowData={contacts}
+        columnData={NOTES_TABLE_COLUMN_DATA}
+        allowRowClick={true}
+      />
+    </div>
+  </AlertContext.Provider>
 );
 
 export default Table;
+export { useDeletAlertContext, RowSettingsIcon };

--- a/app/javascript/src/components/Dashboard/Contacts/constants.js
+++ b/app/javascript/src/components/Dashboard/Contacts/constants.js
@@ -1,8 +1,9 @@
 import React from "react";
 
-import { MenuHorizontal } from "@bigbinary/neeto-icons";
 import { Avatar, Typography } from "neetoui";
 import * as yup from "yup";
+
+import { RowSettingsIcon } from "./Table";
 
 function noOp() {}
 
@@ -52,7 +53,7 @@ export const NOTES_TABLE_COLUMN_DATA = [
   },
   {
     title: "settings",
-    render: () => <MenuHorizontal color="#68737d" size="24" />,
+    render: RowSettingsIcon,
     dataIndex: "settings",
     key: "settings",
     width: "20%",

--- a/app/javascript/src/components/Dashboard/Contacts/index.jsx
+++ b/app/javascript/src/components/Dashboard/Contacts/index.jsx
@@ -6,8 +6,9 @@ import { Container, Header } from "neetoui/layouts";
 
 import EmptyState from "components/Common/EmptyState";
 
-import { MOCK_CONTACTS } from "./constants";
+import { MOCK_CONTACTS, NO_OP_FUNCTION } from "./constants";
 import SideMenu from "./ContactsMenu";
+import DeleteAlert from "./DeleteAlert";
 import NewContactPane from "./Pane/Create";
 import Table from "./Table";
 import { createMockArray } from "./utils";
@@ -18,6 +19,7 @@ const Contacts = () => {
   const [showMenu, setShowMenu] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [showNewContactPane, setShowNewContactPane] = useState(false);
+  const [showDeleteAlert, setShowDeleteAlert] = useState(false);
 
   return (
     <>
@@ -39,7 +41,7 @@ const Contacts = () => {
           }}
         />
         {contacts.length ? (
-          <Table contacts={contacts} />
+          <Table contacts={contacts} setShowDeleteAlert={setShowDeleteAlert} />
         ) : (
           <EmptyState
             image={EmptyNotesListImage}
@@ -53,6 +55,12 @@ const Contacts = () => {
           showPane={showNewContactPane}
           setShowPane={setShowNewContactPane}
         />
+        {showDeleteAlert && (
+          <DeleteAlert
+            onClose={() => setShowDeleteAlert(false)}
+            refetch={NO_OP_FUNCTION}
+          />
+        )}
       </Container>
     </>
   );


### PR DESCRIPTION
## current progress screenshot
![delete-contact](https://user-images.githubusercontent.com/17087942/161042940-f81d8e2a-5a6b-45f1-b9e6-3884be62b465.png)

## additional comments

the following bit is from `app/javascript/src/components/Dashboard/Contacts/Table.jsx` . I needed this to make the `setShowDeleteAlert` available to the children rendered by neetoUI's table. Since the children are rendered implicitly I needed a way to make this value available to them so I used context. Since the context is only relevant to that part of the tree, I didn't move it into a separate file.
```js
const AlertContext = React.createContext();

const useDeletAlertContext = () => {
  const { setShowDeleteAlert } = React.useContext(AlertContext);

  if (!setShowDeleteAlert) {
    throw new Error(
      "setShowDeleteAlert is only available inside AlertContext provider"
    );
  }

  return { setShowDeleteAlert };
};

const RowSettingsIcon = () => {
  const { setShowDeleteAlert } = useDeletAlertContext();

  return (
    <Button style="text" icon={MenuHorizontal} onClick={setShowDeleteAlert} />
  );
};
```
